### PR TITLE
Add support for publishing shape data

### DIFF
--- a/client/ayon_mocha/addon.py
+++ b/client/ayon_mocha/addon.py
@@ -4,14 +4,14 @@ from __future__ import annotations
 import os
 from typing import Any
 
-from ayon_core.addon import AYONAddon, IHostAddon, IPluginPaths
+from ayon_core.addon import AYONAddon, IHostAddon
 
 from .version import __version__
 
 MOCHA_ADDON_ROOT = os.path.dirname(os.path.abspath(__file__))
 
 
-class MochaAddon(AYONAddon, IHostAddon, IPluginPaths):
+class MochaAddon(AYONAddon, IHostAddon):
     """BorisFX Mocha Pro addon for AYON."""
 
     name = "mocha"

--- a/client/ayon_mocha/api/lib.py
+++ b/client/ayon_mocha/api/lib.py
@@ -25,6 +25,27 @@ if TYPE_CHECKING:
 EXTENSION_PATTERN = re.compile(r"(?P<name>.+)\(\*\.(?P<ext>\w+)\)")
 
 
+SHAPE_EXPORTERS_REPRESENTATION_NAME_MAPPING = {
+    "Adobe After Effects Mask Data (*.shape4ae)": "AfxMask",
+    "Adobe Premiere shape data (*.xml)": "PremiereShape",
+    "BlackMagic Fusion 19+ MultiPoly shapes (*.comp)": "FusionMultiPoly",
+    "BlackMagic Fusion shapes (*.comp)": "FusionShapes",
+    "Combustion GMask Script (*.gmask)": "CombustionGMask",
+    "Flame GMask Script (*.gmask)": "FlameGMask",
+    "Flame Tracer [Basic] (*.mask)": "FlameTracerBasic",
+    "Flame Tracer [Shape + Axis] (*.mask)": "FlameTracerShapeAxis",
+    "HitFilm [Transform & Shape] (*.hfcs)": "HitFilmTransformShape",
+    "Mocha shape data for Final Cut (*.xml)": "MochaShapeFinalCut",
+    "MochaBlend shape data (*.txt)": "MochaBlend",
+    "Nuke Roto [Basic] (*.nk)": "NuRotoBasic",
+    "Nuke RotoPaint [Basic] (*.nk)": "NukeRotoPaintBasic",
+    "Nuke SplineWarp (*.nk)": "NukeSplineWarp",
+    "Nuke v6.2+ Roto [Transform & Shape] (*.nk)": "NukeRotoTransformShape",
+    "Nuke v6.2+ RotoPaint [Transform & Shape] (*.nk)": "NukeRotoPaint",
+    "Shake Rotoshape (*.ssf)": "ShapeRotoshape",
+    "Silhouette shapes (*.fxs)": "SilhouetteShapes",
+}
+
 """
 These dataclasses are here because they
 cannot be defined directly in pyblish plugins.
@@ -39,6 +60,7 @@ class ExporterInfo:
     id: str
     label: str
     exporter: Union[TrackingDataExporter, ShapeDataExporter]
+    short_name: str
 
 
 @dataclasses.dataclass
@@ -173,7 +195,9 @@ def get_shape_exporters() -> list[ExporterInfo]:
         ExporterInfo(
             id=sha256(k.encode()).hexdigest(),
             label=k,
-            exporter=v)
+            exporter=v,
+            short_name=SHAPE_EXPORTERS_REPRESENTATION_NAME_MAPPING.get(k, k)
+        )
         for k, v in sorted(
             ShapeDataExporter.registered_exporters().items())
     ]

--- a/client/ayon_mocha/api/pipeline.py
+++ b/client/ayon_mocha/api/pipeline.py
@@ -32,14 +32,14 @@ from mocha.project import get_current_project as _get_current_project
 
 from ayon_mocha.api.lib import update_ui
 
-from .lib import create_empy_project, get_main_window
+from .lib import create_empty_project, get_main_window
 from .workio import current_file, file_extensions, open_file, save_file
 
 if TYPE_CHECKING:
     from qtpy import QtWidgets
 
 log = logging.getLogger("ayon_mocha")
-HOST_DIR = Path(__file__).resolve().parent
+HOST_DIR = Path(__file__).resolve().parent.parent
 PLUGINS_DIR = HOST_DIR / "plugins"
 PUBLISH_PATH = PLUGINS_DIR / "publish"
 LOAD_PATH =  PLUGINS_DIR / "load"
@@ -57,6 +57,26 @@ MOCHA_CONTEXT_KEY = "context"
 MOCHA_INSTANCES_KEY = "publish_instances"
 MOCHA_CONTAINERS_KEY = "containers"
 
+SHAPE_EXPORTERS_REPRESENTATION_NAME_MAPPING = {
+    "Adobe After Effects Mask Data (*.shape4ae)": "AfxMask",
+    "Adobe Premiere shape data (*.xml)": "PremiereShape",
+    "BlackMagic Fusion 19+ MultiPoly shapes (*.comp)": "FusionMultiPoly",
+    "BlackMagic Fusion shapes (*.comp)": "FusionShapes",
+    "Combustion GMask Script (*.gmask)": "CombustionGMask",
+    "Flame GMask Script (*.gmask)": "FlameGMask",
+    "Flame Tracer [Basic] (*.mask)": "FlameTracerBasic",
+    "Flame Tracer [Shape + Axis] (*.mask)": "FlameTracerShapeAxis",
+    "HitFilm [Transform & Shape] (*.hfcs)": "HitFilmTransformShape",
+    "Mocha shape data for Final Cut (*.xml)": "MochaShapeFinalCut",
+    "MochaBlend shape data (*.txt)": "MochaBlend",
+    "Nuke Roto [Basic] (*.nk)": "NuRotoBasic",
+    "Nuke RotoPaint [Basic] (*.nk)": "NukeRotoPaintBasic",
+    "Nuke SplineWarp (*.nk)": "NukeSplineWarp",
+    "Nuke v6.2+ Roto [Transform & Shape] (*.nk)": "NukeRotoTransformShape",
+    "Nuke v6.2+ RotoPaint [Transform & Shape] (*.nk)": "NukeRotoPaint",
+    "Shake Rotoshape (*.ssf)": "ShapeRotoshape",
+    "Silhouette shapes (*.fxs)": "SilhouetteShapes",
+}
 
 class AYONJSONEncoder(json.JSONEncoder):
     """Custom JSON encoder for dataclasses."""
@@ -424,7 +444,7 @@ class MochaProHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
                     parent=get_main_window(),
                 )
                 self._uninitialized_project_warning_shown = True
-            return create_empy_project()
+            return create_empty_project()
         return project
 
 

--- a/client/ayon_mocha/api/pipeline.py
+++ b/client/ayon_mocha/api/pipeline.py
@@ -30,9 +30,8 @@ from ayon_core.tools.utils.dialogs import show_message_dialog
 from mocha.project import Project
 from mocha.project import get_current_project as _get_current_project
 
-from ayon_mocha.api.lib import update_ui
+from ayon_mocha.api.lib import create_empty_project, get_main_window, update_ui
 
-from .lib import create_empty_project, get_main_window
 from .workio import current_file, file_extensions, open_file, save_file
 
 if TYPE_CHECKING:
@@ -57,26 +56,6 @@ MOCHA_CONTEXT_KEY = "context"
 MOCHA_INSTANCES_KEY = "publish_instances"
 MOCHA_CONTAINERS_KEY = "containers"
 
-SHAPE_EXPORTERS_REPRESENTATION_NAME_MAPPING = {
-    "Adobe After Effects Mask Data (*.shape4ae)": "AfxMask",
-    "Adobe Premiere shape data (*.xml)": "PremiereShape",
-    "BlackMagic Fusion 19+ MultiPoly shapes (*.comp)": "FusionMultiPoly",
-    "BlackMagic Fusion shapes (*.comp)": "FusionShapes",
-    "Combustion GMask Script (*.gmask)": "CombustionGMask",
-    "Flame GMask Script (*.gmask)": "FlameGMask",
-    "Flame Tracer [Basic] (*.mask)": "FlameTracerBasic",
-    "Flame Tracer [Shape + Axis] (*.mask)": "FlameTracerShapeAxis",
-    "HitFilm [Transform & Shape] (*.hfcs)": "HitFilmTransformShape",
-    "Mocha shape data for Final Cut (*.xml)": "MochaShapeFinalCut",
-    "MochaBlend shape data (*.txt)": "MochaBlend",
-    "Nuke Roto [Basic] (*.nk)": "NuRotoBasic",
-    "Nuke RotoPaint [Basic] (*.nk)": "NukeRotoPaintBasic",
-    "Nuke SplineWarp (*.nk)": "NukeSplineWarp",
-    "Nuke v6.2+ Roto [Transform & Shape] (*.nk)": "NukeRotoTransformShape",
-    "Nuke v6.2+ RotoPaint [Transform & Shape] (*.nk)": "NukeRotoPaint",
-    "Shake Rotoshape (*.ssf)": "ShapeRotoshape",
-    "Silhouette shapes (*.fxs)": "SilhouetteShapes",
-}
 
 class AYONJSONEncoder(json.JSONEncoder):
     """Custom JSON encoder for dataclasses."""

--- a/client/ayon_mocha/plugins/create/create_shape_data.py
+++ b/client/ayon_mocha/plugins/create/create_shape_data.py
@@ -26,6 +26,21 @@ class CreateShapeData(MochaCreator):
     def get_attr_defs_for_instance(self, instance: CreatedInstance) -> list:
         """Get attribute definitions for instance."""
         exporter_items = {ex.id: ex.label for ex in get_shape_exporters()}
+
+        settings = (
+            self.project_settings
+            ["mocha"]["create"]["CreateShapeData"]
+        )
+
+        exporters = get_shape_exporters()
+        exporter_items = {ex.id: ex.label for ex in exporters}
+
+        preselect_exporters = [
+            ex.id
+            for ex in exporters
+            if ex.short_name in settings["default_exporters"]
+        ]
+
         layers = {
                     idx: layer.name
                     for idx, layer in enumerate(
@@ -39,7 +54,9 @@ class CreateShapeData(MochaCreator):
                     multiselection=True),
             EnumDef("exporter",
                     label="Exporter format",
-                    items=exporter_items, multiselection=True),
+                    items=exporter_items,
+                    multiselection=True,
+                    default=preselect_exporters),
             UISeparatorDef(),
             UILabelDef(
                 "Exporter Options (not all are available in all exporters)"),

--- a/client/ayon_mocha/plugins/create/create_shape_data.py
+++ b/client/ayon_mocha/plugins/create/create_shape_data.py
@@ -1,0 +1,51 @@
+"""Create shape data instance."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ayon_core.lib import (
+    EnumDef,
+    UILabelDef,
+    UISeparatorDef,
+)
+from ayon_mocha.api.lib import get_shape_exporters
+from ayon_mocha.api.plugin import MochaCreator
+
+if TYPE_CHECKING:
+    from ayon_core.pipeline import CreatedInstance
+
+
+class CreateShapeData(MochaCreator):
+    """Create shape instance."""
+    identifier = "io.ayon.creators.mochapro.matteshapes"
+    label = "Shape Data"
+    description = __doc__
+    product_type = "matteshapes"
+    icon = "circle"
+
+    def get_attr_defs_for_instance(self, instance: CreatedInstance) -> list:
+        """Get attribute definitions for instance."""
+        exporter_items = {ex.id: ex.label for ex in get_shape_exporters()}
+        layers = {
+                    idx: layer.name
+                    for idx, layer in enumerate(
+                        self.create_context.host.get_current_project().layers)
+                } or {-1: "No layers"}
+
+        return [
+            EnumDef("layers",
+                    label="Layers",
+                    items=layers,
+                    multiselection=True),
+            EnumDef("exporter",
+                    label="Exporter format",
+                    items=exporter_items, multiselection=True),
+            UISeparatorDef(),
+            UILabelDef(
+                "Exporter Options (not all are available in all exporters)"),
+            EnumDef("layer_mode", label="Layer mode",
+                    items={
+                        "selected": "Selected layers",
+                        "all": "All layers"
+                    }),
+        ]

--- a/client/ayon_mocha/plugins/load/load_trackable_clip.py
+++ b/client/ayon_mocha/plugins/load/load_trackable_clip.py
@@ -54,7 +54,8 @@ class LoadTrackableClip(MochaLoader):
 
             for cnt in host.get_containers():
                 if cnt.get("name") == current_clip.name:
-                    cnt["representation"] = str(context["representation"]["id"])
+                    cnt["representation"] = str(
+                        context["representation"]["id"])
                     return
 
             container = Container(

--- a/client/ayon_mocha/plugins/publish/collect_instances.py
+++ b/client/ayon_mocha/plugins/publish/collect_instances.py
@@ -1,0 +1,48 @@
+"""Collect instances for publishing."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, ClassVar
+
+import pyblish.api
+
+if TYPE_CHECKING:
+    from logging import Logger
+
+class CollectInstances(pyblish.api.InstancePlugin):
+    """Collect instances for publishing."""
+    label = "Collect Instances"
+    order = pyblish.api.CollectorOrder - 0.4
+    hosts: ClassVar[list[str]] = ["mochapro"]
+    log: Logger
+
+    def process(self, instance: pyblish.api.Instance) -> None:
+        """Process the plugin."""
+        self.log.debug("Collecting data for %s", instance)
+
+        # Define nice instance label
+        instance_node = instance.data.get(
+            "transientData", {}).get("instance_node")
+        name = instance_node.label if instance_node else instance.name
+        label = f"{name} ({instance.data['folderPath']})"
+
+        # Set frame start handle and frame end handle if frame ranges are
+        # available
+        if "frameStart" in instance.data and "frameEnd" in instance.data:
+            # Enforce existence if handles
+            instance.data.setdefault("handleStart", 0)
+            instance.data.setdefault("handleEnd", 0)
+
+            # Compute frame start handle and end start handle
+            frame_start_handle = (
+                instance.data["frameStart"] - instance.data["handleStart"]
+            )
+            frame_end_handle = (
+                instance.data["frameEnd"] - instance.data["handleEnd"]
+            )
+            instance.data["frameStartHandle"] = frame_start_handle
+            instance.data["frameEndHandle"] = frame_end_handle
+
+            # Include frame range in label
+            label += f"  [{int(frame_start_handle)}-{int(frame_end_handle)}]"
+
+        instance.data["label"] = label

--- a/client/ayon_mocha/plugins/publish/collect_mocha_paths.py
+++ b/client/ayon_mocha/plugins/publish/collect_mocha_paths.py
@@ -1,0 +1,59 @@
+"""Collect Mocha executable paths."""
+from __future__ import annotations
+
+import platform
+from pathlib import Path
+from typing import TYPE_CHECKING, ClassVar
+
+import pyblish.api
+from mocha import get_mocha_exec_name
+
+if TYPE_CHECKING:
+    from logging import Logger
+
+    from mocha.project import Project
+
+class CollectMochaPaths(pyblish.api.ContextPlugin):
+    """Collect Mocha Pro project."""
+    order = pyblish.api.CollectorOrder - 0.45
+    label = "Collect Mocha Pro executables"
+    hosts: ClassVar[list[str]] = ["mochapro"]
+    log: Logger
+
+    def process(self, context: pyblish.api.Context) -> None:
+        """Process the plugin."""
+        project: Project = context.data["project"]
+        self.log.info("Collected Mocha Pro project: %s", project)
+
+        mocha_executable_path = Path(get_mocha_exec_name("mochapro"))
+        context.data["mocha_executable_path"] = mocha_executable_path
+        mocha_install_dir = mocha_executable_path.parent.parent
+
+        if platform.system().lower() == "windows":
+            mocha_python_path = (
+                mocha_install_dir / "python" / "python.exe")
+            mocha_exporter_path = (
+                mocha_install_dir / "python" / "mochaexport.py")
+        elif platform.system().lower() == "darwin":
+            mocha_python_path = (
+                mocha_install_dir / "python3")
+            mocha_exporter_path = (
+                mocha_install_dir / "mochaexport.py")
+        elif platform.system().lower() == "linux":
+            mocha_python_path = (
+                mocha_install_dir / "python" / "bin" / "python3")
+            mocha_exporter_path = (
+                mocha_install_dir / "python" / "mochaexport.py")
+        else:
+            msg = f"Unsupported platform: {platform.system()}"
+            raise NotImplementedError(msg)
+
+        context.data["mocha_python_path"] = mocha_python_path
+        context.data["mocha_exporter_path"] = mocha_exporter_path
+
+        self.log.info("Collected Mocha Pro executable path: %s",
+                      mocha_executable_path)
+        self.log.info("Collected Mocha Pro python executable path: %s",
+                      mocha_python_path)
+        self.log.info("Collected Mocha Pro python export script path: %s",
+                      mocha_exporter_path)

--- a/client/ayon_mocha/plugins/publish/collect_mocha_project.py
+++ b/client/ayon_mocha/plugins/publish/collect_mocha_project.py
@@ -1,0 +1,32 @@
+"""Collect the current Mocha Pro project."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, ClassVar
+
+import pyblish.api
+from mocha.project import get_current_project
+
+if TYPE_CHECKING:
+    from logging import Logger
+
+
+class CollectMochaProject(pyblish.api.ContextPlugin):
+    """Inject the current working file into context.
+
+    Foo batr baz.
+    """
+
+    order = pyblish.api.CollectorOrder - 0.5
+    label = "Collect Mocha Pro Project"
+    hosts: ClassVar[list[str]] = ["mochapro"]
+    log: Logger
+
+    def process(self, context: pyblish.api.Context) -> None:
+        """Inject the current working file."""
+        context.data["project"] = get_current_project()
+        current_file = context.data["project"].project_file
+        context.data["currentFile"] = current_file
+        if not current_file:
+            self.log.warning(
+                "Current file is not saved. Save the file before continuing."
+            )

--- a/client/ayon_mocha/plugins/publish/collect_shapes.py
+++ b/client/ayon_mocha/plugins/publish/collect_shapes.py
@@ -1,0 +1,103 @@
+"""Collect layers for shape export."""
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import TYPE_CHECKING, ClassVar
+
+import pyblish.api
+from ayon_core.pipeline import KnownPublishError
+from ayon_core.pipeline.create import get_product_name
+from ayon_mocha.api.lib import get_shape_exporters
+
+if TYPE_CHECKING:
+    from logging import Logger
+
+    from ayon_core.pipeline.create import CreateContext
+    from mocha.project import Layer, Project
+
+
+class CollectShapes(pyblish.api.InstancePlugin):
+    """Collect trackpoint data."""
+    label = "Collect Shape Data"
+    order = pyblish.api.CollectorOrder - 0.45
+    hosts: ClassVar[list[str]] = ["mochapro"]
+    families: ClassVar[list[str]] = ["matteshapes"]
+    log: Logger
+
+
+    @staticmethod
+    def new_product_name(
+        create_context: CreateContext,
+        layer_name: str,
+        product_type: str,
+        variant: str) -> str:
+        """Return the new product name."""
+        sanitized_layer_name = layer_name.replace(" ", "_")
+        variant = f"{sanitized_layer_name}{variant.capitalize()}"
+
+        return get_product_name(
+            project_name=create_context.project_name,
+            task_name=create_context.get_current_task_name(),
+            task_type=create_context.get_current_task_type(),
+            host_name=create_context.host_name,
+            product_type=product_type,
+            variant=variant,
+        )
+
+    def process(self, instance: pyblish.api.Instance) -> None:
+        """Process the instance."""
+        # copy creator settings to the instance itself
+        creator_attrs = instance.data["creator_attributes"]
+        registered_exporters = get_shape_exporters()
+        selected_exporters = [
+            exporter
+            for exporter in registered_exporters
+            if exporter.id in creator_attrs["exporter"]
+        ]
+
+        instance.data["use_exporters"] = selected_exporters
+        project: Project = instance.context.data["project"]
+        layers: list[Layer] = []
+        if creator_attrs["layer_mode"] == "selected":
+            layers.extend(
+                project.layers[selected_layer_idx]
+                for selected_layer_idx in creator_attrs["layers"]
+            )
+        elif creator_attrs["layer_mode"] == "all":
+            layers = project.layers
+        else:
+            msg = f"Invalid layer mode: {creator_attrs['layer_mode']}"
+            raise KnownPublishError(msg)
+
+        for layer in layers:
+            new_instance = instance.context.create_instance(
+                f"{instance.name} - {layer.name}"
+            )
+            for k, v in instance.data.items():
+                # this is needed because the data is not always
+                # "deepcopyable".
+                try:
+                    new_instance.data[k] = deepcopy(v)
+                except TypeError:  # noqa: PERF203
+                    new_instance.data[k] = v
+
+            # new_instance.data = instance.data
+            new_instance.data["label"] = f"{instance.name} ({layer.name})"
+            new_instance.data["name"] = f"{instance.name}_{layer.name}"
+            new_instance.data["productName"] = self.new_product_name(
+                instance.context.data["create_context"],
+                layer.name,
+                instance.data["productType"],
+                instance.data["variant"],
+            )
+            self.set_layer_data_on_instance(new_instance, layer)
+        if layers:
+            instance.context.remove(instance)
+
+
+    def set_layer_data_on_instance(
+            self, instance: pyblish.api.Instance, layer: Layer) -> None:
+        """Set data on instance."""
+        instance.data["layer"] = layer
+        instance.data["frameStart"] = layer.in_point()
+        instance.data["frameEnd"] = layer.out_point()

--- a/client/ayon_mocha/plugins/publish/export_shapes.py
+++ b/client/ayon_mocha/plugins/publish/export_shapes.py
@@ -1,0 +1,262 @@
+"""Extract tracking points from Mocha."""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING, ClassVar, List, Optional
+
+import clique
+from ayon_core.pipeline import KnownPublishError, publish
+from ayon_mocha.api.lib import ExporterProcessInfo
+from ayon_mocha.api.pipeline import SHAPE_EXPORTERS_REPRESENTATION_NAME_MAPPING
+from mocha.project import Layer, Project, View
+
+if TYPE_CHECKING:
+    from logging import Logger
+
+    import pyblish.api
+    from ayon_mocha.api.lib import ExporterInfo
+
+EXTENSION_PATTERN = re.compile(r"(?P<name>.+)\(\*\.(?P<ext>\w+)\)")
+
+
+class ExportShape(publish.Extractor):
+    """Export shapes."""
+
+    label = "Export Shapes"
+    families: ClassVar[list[str]] = ["matteshapes"]
+    log: Logger
+
+    def process(self, instance: pyblish.api.Instance) -> None:
+        """Process the instance."""
+        dir_path = Path(self.staging_dir(instance))
+        project: Project = instance.context.data["project"]
+        layer: Layer = instance.data["layer"]
+
+        process_info = ExporterProcessInfo(
+            mocha_python_path=instance.context.data["mocha_python_path"],
+            mocha_exporter_path=instance.context.data["mocha_exporter_path"],
+            current_project_path=instance.context.data["currentFile"],
+            staging_dir=dir_path,
+            options={}
+        )
+
+        outputs = self.export(
+            instance.data["productName"],
+            project,
+            instance.data["use_exporters"],
+            layer,
+            process_info,
+        )
+
+        representations = self.process_outputs_to_representations(
+            outputs, instance)
+
+        instance.data.setdefault(
+            "representations", []).extend(representations)
+
+        self.log.debug(instance.data["representations"])
+
+
+    def process_outputs_to_representations(
+            self, outputs: list[dict],
+            instance: pyblish.api.Instance) -> list[dict]:
+        """Process the output to representations."""
+        representations = []
+        staging_dir = Path(self.staging_dir(instance))
+
+        for output in outputs:
+            # if there are multiple files in one representation
+            # we need to check if it is sequence or not as current
+            # integration does not support multiple files that are not
+            # in sequences.
+            repre_name = self._exporter_name_to_representation_name(
+                output["name"])
+
+            cols, rems = clique.assemble(output["files"])
+            if rems and cols:
+                # there are both sequences and single files
+                if cols > 1:
+                    # the extractor produced multiple sequences
+                    # and single files. This is not supported now
+                    # due to the complexity.
+                    msg = ("The exporter produced multiple sequences "
+                           "and single files. This is not supported.")
+                    raise KnownPublishError(msg)
+                output_files = cols[0]
+                for reminder in rems:
+                    self.add_to_resources(
+                        Path(self.staging_dir(instance)) / reminder, instance)
+                representations.append({
+                    "name": repre_name,
+                    "ext": output["ext"],
+                    "files": output_files,
+                    "stagingDir": output["stagingDir"],
+                    "outputName": output["outputName"],
+                })
+            if rems and not cols:
+                if len(rems) > 1:
+                    # if there are only non-sequence files
+                    for reminder in rems:
+                        self.add_to_resources(
+                            Path(self.staging_dir(instance)) / reminder, instance)  # noqa: E501
+                    manifest_file = self._create_manifest_file(
+                        staging_dir, rems, repre_name)
+                    representations.append({
+                        "name": repre_name,
+                        "ext": output["ext"],
+                        "files": manifest_file,
+                        "stagingDir": output["stagingDir"],
+                        "outputName": output["outputName"],
+                    })
+                else:
+                    # if there is only one non-sequence file
+                    representations.append({
+                        "name": repre_name,
+                        "ext": output["ext"],
+                        "files": rems[0],
+                        "stagingDir": output["stagingDir"],
+                        "outputName": output["outputName"],
+                    })
+            if cols and not rems:
+                # if there are only sequences
+                if cols > 1:
+                    # the extractor produced multiple sequences
+                    # and single files. This is not supported now
+                    # due to the complexity.
+                    msg = ("The exporter produced multiple sequences "
+                           "and single files. This is not supported.")
+                    raise KnownPublishError(msg)
+                representations.append({
+                    "name": repre_name,
+                    "ext": output["ext"],
+                    "files": list(cols[0]),
+                    "stagingDir": output["stagingDir"],
+                    "outputName": output["outputName"],
+                })
+        return representations
+
+    @staticmethod
+    def _create_manifest_file(
+            staging_dir: Path, files: list[str], repre_name: str) -> str:
+        """Create a manifest file.
+
+        This will put all the files to a manifest file that
+        will be used as a representation. This is because the
+        current integration does not support multiple files
+        that are not in sequences.
+
+        Args:
+            staging_dir (Path): staging directory.
+            files (list[str]): list of files.
+            repre_name (str): representation name.
+
+        """
+        file_name = f"{repre_name}.manifest"
+        manifest_file = staging_dir / file_name
+        with open(manifest_file, "w") as file:
+            for file_path in files:
+                file.write(f"{file_path}\n")
+        return file_name
+
+    def export(
+            self,
+            product_name: str,
+            project: Project,
+            exporters: list[ExporterInfo],
+            layer: Layer,
+            process_info: ExporterProcessInfo
+        ) -> list[dict]:
+        """Export the instance.
+
+        This is using in-process export but since the export
+        times are pretty fast, it's easier and probably
+        faster than using the external export.
+
+        Args:
+            product_name (str): used for naming the resulting
+                files.
+            project (Project): Mocha project.
+            exporters (list[ExporterInfo]): exporters to use.
+            layer (Layer): layer to export.
+            process_info (ExporterProcessInfo): process information.
+
+        """
+        views = [view_info.name for view_info in project.views]
+        views_to_export: set[View] = {
+            View(num)
+            for num, view_info in enumerate(project.views)
+            if view_info.name in views or view_info.abbr in views
+        }
+
+        output: list[dict] = []
+        for exporter_info in exporters:
+            exporter_name = exporter_info.label
+            if not exporter_name:
+                msg = ("Cannot get exporter name "
+                       f"from {exporter_info.label} exporter.")
+                raise KnownPublishError(msg)
+
+            ext = self._get_extension(exporter_info)
+            if not ext:
+                msg = ("Cannot get extension "
+                       f"from {exporter_info.label} exporter.")
+                raise KnownPublishError(msg)
+
+            exporter_short_hash = exporter_info.id[:8]
+            file_name = f"{product_name}_{exporter_short_hash}.{ext}"
+
+            tracking_file_path = (
+                    process_info.staging_dir / file_name
+            )
+            # this is for some reason needed to pass it to `do_render()`
+            views_typed: List[View] = list(views_to_export)
+            layers_typed: List[Layer] = [layer]
+            result = exporter_info.exporter.do_export(
+                project,
+                layers_typed,
+                tracking_file_path.as_posix(),
+                views_typed
+            )
+
+            if not result:
+                msg = f"Export failed for {exporter_name}."
+                raise KnownPublishError(msg)
+
+            output_files = []
+            for k, v in result.items():
+                with open(k, "wb") as file:
+                    file.write(v)
+                output_files.append(Path(k).name)
+
+            output.append({
+                "name": exporter_info.label,
+                "ext": ext,
+                "files": output_files,
+                "stagingDir": process_info.staging_dir.as_posix(),
+                "outputName": exporter_short_hash,
+            })
+
+        return output
+
+    def add_to_resources(
+            self, path: Path, instance: pyblish.api.Instance) -> None:
+        """Add the path to the resources."""
+        self.log.debug("Adding to resources: %s", path)
+
+        publish_dir_path = Path(instance.data["publishDir"])
+        instance.data["transfers"].append(
+            [path.as_posix(),  (publish_dir_path / path.name).as_posix()])
+
+
+    @staticmethod
+    def _get_extension(exporter_info: ExporterInfo) -> Optional[str]:
+        """Get the extension of the exporter."""
+        match = re.search(EXTENSION_PATTERN, exporter_info.label)
+        return match["ext"] if match else None
+
+    def _exporter_name_to_representation_name(
+            self, exporter_name: str) -> str:
+        """Convert the exporter name to representation name."""
+        return SHAPE_EXPORTERS_REPRESENTATION_NAME_MAPPING.get(
+            exporter_name, exporter_name)

--- a/client/ayon_mocha/plugins/publish/export_shapes.py
+++ b/client/ayon_mocha/plugins/publish/export_shapes.py
@@ -7,8 +7,10 @@ from typing import TYPE_CHECKING, ClassVar, List, Optional
 
 import clique
 from ayon_core.pipeline import KnownPublishError, publish
-from ayon_mocha.api.lib import ExporterProcessInfo
-from ayon_mocha.api.pipeline import SHAPE_EXPORTERS_REPRESENTATION_NAME_MAPPING
+from ayon_mocha.api.lib import (
+    SHAPE_EXPORTERS_REPRESENTATION_NAME_MAPPING,
+    ExporterProcessInfo,
+)
 from mocha.project import Layer, Project, View
 
 if TYPE_CHECKING:

--- a/client/ayon_mocha/plugins/publish/validate_layers_and_exporters.py
+++ b/client/ayon_mocha/plugins/publish/validate_layers_and_exporters.py
@@ -1,0 +1,61 @@
+"""Validate layers and exportes."""
+from __future__ import annotations
+
+import inspect
+from typing import TYPE_CHECKING, ClassVar
+
+import pyblish.api
+from ayon_core.pipeline import PublishValidationError
+
+if TYPE_CHECKING:
+    from logging import Logger
+
+
+class ValidateLayersAndExporters(pyblish.api.InstancePlugin):
+    """Validate layers and exporters set."""
+
+    order = pyblish.api.Validator.order + 0.1
+    label = "Validate Exporters and Layers"
+    hosts: ClassVar[list[str]] = ["mochapro"]
+    families: ClassVar[list[str]] = ["matteshapes", "trackpoints"]
+    log: Logger
+
+    def process(self, instance: pyblish.api.Instance) -> None:
+        """Process all the trackpoints."""
+        self.log.debug("Validating layers and exporters")
+        if not instance.data.get("layer"):
+            msg = (
+                f"No layers set for instance {instance.name}"
+            )
+            raise PublishValidationError(
+                msg, description=self._missing_layer_description())
+
+        if not instance.data.get("use_exporters"):
+            msg = (
+                f"No exporters set for instance {instance.name}"
+            )
+            raise PublishValidationError(
+                msg, description=self._missing_exporter())
+
+    @classmethod
+    def _missing_layer_description(cls) -> str:
+        """Return the description for missing layer."""
+        return inspect.cleandoc(
+            """
+            ### Issue
+
+            The instance doesn't have layers set. Please select the layer
+            in the publisher,or set the layer mode to "All layers".
+            """
+        )
+
+    @classmethod
+    def _missing_exporter(cls) -> str:
+        """Return the description for missing layer."""
+        return inspect.cleandoc(
+            """
+            ### Issue
+
+            You need to select at least one exporter.
+            """
+        )

--- a/client/ayon_mocha/version.py
+++ b/client/ayon_mocha/version.py
@@ -1,3 +1,3 @@
-
+# -*- coding: utf-8 -*-
 """Package declaring AYON addon 'mocha' version."""
 __version__ = "0.0.1"

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -5,12 +5,12 @@ from typing import Type
 
 from ayon_server.addons import BaseServerAddon
 
-from .settings import DEFAULT_VALUES, MochaSettings
+from .settings import DEFAULT_VALUES, MochaProSettings
 
 
 class MochaAddon(BaseServerAddon):
     """BorisFX Mocha Pro addon for AYON settings."""
-    settings_model: Type[MochaSettings] = MochaSettings
+    settings_model: Type[MochaProSettings] = MochaProSettings
 
     async def get_default_settings(self) -> dict:
         """Return default settings."""

--- a/server/settings/__init__.py
+++ b/server/settings/__init__.py
@@ -1,0 +1,7 @@
+"""Settings module for the server package."""
+from .main import DEFAULT_VALUES, MochaProSettings
+
+__all__ = [
+    "DEFAULT_VALUES",
+    "MochaProSettings",
+]

--- a/server/settings/creator_plugins.py
+++ b/server/settings/creator_plugins.py
@@ -1,0 +1,79 @@
+"""Creator settings for Mocha Pro."""
+from __future__ import annotations
+
+from ayon_server.settings import BaseSettingsModel, SettingsField
+
+
+def shapes_exporter_enum() -> list[dict[str, str]]:
+    """Return enum for shape exporters."""
+    return [
+        {
+            "label": "Adobe After Effects Mask Data (*.shape4ae)",
+            "value": "AfxMask"},
+        {
+            "label": "Adobe Premiere shape data (*.xml)",
+            "value":  "PremiereShape"},
+        {
+            "label": "BlackMagic Fusion 19+ MultiPoly shapes (*.comp)",
+            "value":  "FusionMultiPoly"},
+        {
+            "label": "BlackMagic Fusion shapes (*.comp)",
+            "value":  "FusionShapes"},
+        {
+            "label": "Combustion GMask Script (*.gmask)",
+            "value":  "CombustionGMask"},
+        {
+            "label": "Flame GMask Script (*.gmask)",
+            "value":  "FlameGMask"},
+        {
+            "label": "Flame Tracer [Basic] (*.mask)",
+            "value":  "FlameTracerBasic"},
+        {
+            "label": "Flame Tracer [Shape + Axis] (*.mask)",
+            "value":  "FlameTracerShapeAxis"},
+        {
+            "label": "HitFilm [Transform & Shape] (*.hfcs)",
+            "value":  "HitFilmTransformShape"},
+        {
+            "label": "Mocha shape data for Final Cut (*.xml)",
+            "value":  "MochaShapeFinalCut"},
+        {
+            "label": "MochaBlend shape data (*.txt)",
+            "value": "MochaBlend"},
+        {
+            "label": "Nuke Roto [Basic] (*.nk)",
+            "value":  "NuRotoBasic"},
+        {
+            "label": "Nuke RotoPaint [Basic] (*.nk)",
+            "value":  "NukeRotoPaintBasic"},
+        {
+            "label": "Nuke SplineWarp (*.nk)",
+            "value": "NukeSplineWarp"},
+        {
+            "label": "Nuke v6.2+ Roto [Transform & Shape] (*.nk)",
+            "value":  "NukeRotoTransformShape"},
+        {
+            "label": "Nuke v6.2+ RotoPaint [Transform & Shape] (*.nk)",
+            "value":  "NukeRotoPaint"},
+        {
+            "label": "Shake Rotoshape (*.ssf)",
+            "value":  "ShapeRotoshape"},
+        {
+            "label": "Silhouette shapes (*.fxs)",
+            "value":  "SilhouetteShapes"},
+    ]
+
+class CreateShapeDataModel(BaseSettingsModel):
+    """Settings for creating shapes."""
+    enabled: bool = SettingsField(
+        default=True, title="Enabled")
+    default_exporters: list[str] = SettingsField(
+        default_factory=list, title="Default exporters",
+        enum_resolver=shapes_exporter_enum)
+
+
+class MochaProCreatorPlugins(BaseSettingsModel):
+    """Mocha Pro creator plugins settings."""
+    CreateShapeData: CreateShapeDataModel = SettingsField(
+        default_factory=CreateShapeDataModel,
+        title="Create Shapes")

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -1,0 +1,23 @@
+"""Settings for the Mocha Pro Addon."""
+from ayon_server.settings import BaseSettingsModel, SettingsField
+
+from .creator_plugins import MochaProCreatorPlugins
+
+
+class MochaProSettings(BaseSettingsModel):
+    """Settings for the Mocha Pro Addon."""
+    create: MochaProCreatorPlugins = SettingsField(
+        default_factory=MochaProCreatorPlugins,
+        title="Creator Plugins")
+
+
+DEFAULT_VALUES = {
+    "create": {
+        "CreateShapeData": {
+            "enabled": True,
+            "default_exporters": [
+                "SilhouetteShapes",
+            ]
+        }
+    }
+}


### PR DESCRIPTION
## Changelog Description
Adds support for publishing of shape data in similar fashion as tracking data. You can select layers you want to publish and exporters to do the job. It will publish all exporter outputs as representations of selected layers.

## Additional review information
This work in similar fashion as #6 

## Testing notes:
1. create some layers with shapes
2. publish them

> [!NOTE]
> This is already based on #5

Closes #4 
