### PR TITLE
Bug: Fix published file extension in 2024 and older

### DIFF
--- a/client/ayon_mocha/plugins/publish/export_shapes.py
+++ b/client/ayon_mocha/plugins/publish/export_shapes.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
     from ayon_mocha.api.lib import ExporterInfo
 
 EXTENSION_PATTERN = re.compile(r"(?P<name>.+)\(\*\.(?P<ext>\w+)\)")
+MOCHA_2025 = 2025
 
 
 class ExportShape(publish.Extractor):
@@ -231,7 +232,7 @@ class ExportShape(publish.Extractor):
             # label. We add it here so it is later on used from the
             # resulted file name.
             file_name = f"{product_name}_{exporter_short_hash}"
-            if int(version.split(".")[0]) < 2025:
+            if int(version.split(".")[0]) < MOCHA_2025:
                 ext = ExportShape._get_extension(exporter_info)
                 if not ext:
                     msg = ("Cannot get extension "
@@ -263,14 +264,9 @@ class ExportShape(publish.Extractor):
                 Path(k).write_bytes(v)
                 output_files.append(Path(k).name)
 
-                print(f"Exported: {k}")
-                print(f"Ext: {Path(k).suffix[1:]}")
-
-
                 if ext is None:
                     ext = Path(k).suffix[1:]
 
-            print(f"set ext {ext}")
             output.append({
                 "name": exporter_info.label,
                 "ext": ext,

--- a/client/ayon_mocha/plugins/publish/export_shapes.py
+++ b/client/ayon_mocha/plugins/publish/export_shapes.py
@@ -222,20 +222,27 @@ class ExportShape(publish.Extractor):
                        f"from {exporter_info.label} exporter.")
                 raise KnownPublishError(msg)
 
-            """"
-            ext = self._get_extension(exporter_info)
-            if not ext:
-                msg = ("Cannot get extension "
-                       f"from {exporter_info.label} exporter.")
-                raise KnownPublishError(msg)
-            """
-
             exporter_short_hash = exporter_info.id[:8]
+
+            version = get_mocha_version() or "2024"
+
+            # exporters were rewritten in 2025. For older version
+            # we need to parse the file extension from the exporter
+            # label. We add it here so it is later on used from the
+            # resulted file name.
             file_name = f"{product_name}_{exporter_short_hash}"
+            if int(version.split(".")[0]) < 2025:
+                ext = ExportShape._get_extension(exporter_info)
+                if not ext:
+                    msg = ("Cannot get extension "
+                           f"from {exporter_info.label} exporter.")
+                    raise KnownPublishError(msg)
+                file_name += f".{ExportShape._get_extension(exporter_info)}"
 
             tracking_file_path = (
                     process_info.staging_dir / file_name
             )
+
             # this is for some reason needed to pass it to `do_render()`
             views_typed: List[View] = list(views_to_export)
             layers_typed: List[Layer] = [layer]
@@ -256,9 +263,14 @@ class ExportShape(publish.Extractor):
                 Path(k).write_bytes(v)
                 output_files.append(Path(k).name)
 
+                print(f"Exported: {k}")
+                print(f"Ext: {Path(k).suffix[1:]}")
+
+
                 if ext is None:
                     ext = Path(k).suffix[1:]
 
+            print(f"set ext {ext}")
             output.append({
                 "name": exporter_info.label,
                 "ext": ext,

--- a/client/ayon_mocha/plugins/publish/export_shapes.py
+++ b/client/ayon_mocha/plugins/publish/export_shapes.py
@@ -179,8 +179,8 @@ class ExportShape(publish.Extractor):
             file.writelines(files)
         return file_name
 
-    @staticmethod
     def export(
+            self,
             product_name: str,
             project: Project,
             exporters: list[ExporterInfo],
@@ -240,7 +240,7 @@ class ExportShape(publish.Extractor):
                     raise KnownPublishError(msg)
                 file_name += f".{ExportShape._get_extension(exporter_info)}"
 
-            tracking_file_path = (
+            shapes_file_path = (
                     process_info.staging_dir / file_name
             )
 
@@ -250,9 +250,13 @@ class ExportShape(publish.Extractor):
             result = exporter_info.exporter.do_export(
                 project,
                 layers_typed,
-                tracking_file_path.as_posix(),
+                shapes_file_path.as_posix(),
                 views_typed
             )
+            self.log.debug(
+                "Selected exporter: %s", exporter_name)
+            self.log.debug(
+                "Exporting to: %s", shapes_file_path)
 
             if not result:
                 msg = f"Export failed for {exporter_name}."

--- a/client/ayon_mocha/plugins/publish/export_tracking_points.py
+++ b/client/ayon_mocha/plugins/publish/export_tracking_points.py
@@ -244,6 +244,22 @@ class ExportTrackingPoints(publish.Extractor):
             options = process_info.options
 
             exporter_short_hash = exporter_info.id[:8]
+
+            version = get_mocha_version() or "2024"
+
+            # exporters were rewritten in 2025. For older version
+            # we need to parse the file extension from the exporter
+            # label. We add it here so it is later on used from the
+            # resulted file name.
+            file_name = f"{product_name}_{exporter_short_hash}"
+            if int(version.split(".")[0]) < 2025:
+                ext = ExportTrackingPoints._get_extension(exporter_info)
+                if not ext:
+                    msg = ("Cannot get extension "
+                           f"from {exporter_info.label} exporter.")
+                    raise KnownPublishError(msg)
+                file_name += f".{ExportTrackingPoints._get_extension(exporter_info)}"
+
             file_name = f"{product_name}_{exporter_short_hash}"
 
             tracking_file_path = (

--- a/client/ayon_mocha/plugins/publish/export_tracking_points.py
+++ b/client/ayon_mocha/plugins/publish/export_tracking_points.py
@@ -261,8 +261,6 @@ class ExportTrackingPoints(publish.Extractor):
                     raise KnownPublishError(msg)
                 file_name += f".{ExportTrackingPoints._get_extension(exporter_info)}"  # noqa: E501
 
-            file_name = f"{product_name}_{exporter_short_hash}"
-
             tracking_file_path = (
                     process_info.staging_dir / file_name
             )

--- a/client/ayon_mocha/plugins/publish/export_tracking_points.py
+++ b/client/ayon_mocha/plugins/publish/export_tracking_points.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from ayon_mocha.api.lib import ExporterInfo
 
 EXTENSION_PATTERN = re.compile(r"(?P<name>.+)\(\*\.(?P<ext>\w+)\)")
+MOCHA_2025 = 2025
 
 
 class ExportTrackingPoints(publish.Extractor):
@@ -252,13 +253,13 @@ class ExportTrackingPoints(publish.Extractor):
             # label. We add it here so it is later on used from the
             # resulted file name.
             file_name = f"{product_name}_{exporter_short_hash}"
-            if int(version.split(".")[0]) < 2025:
+            if int(version.split(".")[0]) < MOCHA_2025:
                 ext = ExportTrackingPoints._get_extension(exporter_info)
                 if not ext:
                     msg = ("Cannot get extension "
                            f"from {exporter_info.label} exporter.")
                     raise KnownPublishError(msg)
-                file_name += f".{ExportTrackingPoints._get_extension(exporter_info)}"
+                file_name += f".{ExportTrackingPoints._get_extension(exporter_info)}"  # noqa: E501
 
             file_name = f"{product_name}_{exporter_short_hash}"
 


### PR DESCRIPTION
## Changelog Description
Fix for publishing tracking and shape files in Mocha 2024.5 and older where published files were missing correct extension.

## Additional review information
Mocha 2025 changed how exporters are named and how the file in result is treated. In older versions, there is no easy way to determine "correct" file extension for selected exporter - the only way is parsing exporter label which contains it as a string.

## Testing notes:
1. Run **Mocha 2024.5** and publish either shapes or trackpoints
2. Publishing should work and published files should have correct extension

Closes #9 
