### PR TITLE
Set clip resolution

### DIFF
--- a/client/ayon_mocha/api/lib.py
+++ b/client/ayon_mocha/api/lib.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from shutil import copyfile
 from typing import TYPE_CHECKING, Any, Optional, Union
 
+from ayon_core.lib.transcoding import get_oiio_info_for_input
 from mocha import REGISTRY_APPLICATION_NAME, get_mocha_exec_name, ui
 from mocha.exporters import ShapeDataExporter, TrackingDataExporter
 from mocha.project import Clip, Project
@@ -248,3 +249,25 @@ def get_mocha_version() -> Optional[str]:
     result = re.search(
         r"Mocha Pro (?P<version>\d+\.?\d+)", app_name)
     return result["version"] if result else None
+
+
+def get_image_info(path: Path) -> dict:
+    """Get image information using OIIO.
+
+    Args:
+        path (Path): Path to the image file.
+
+    Returns:
+        dict: Image information.
+
+    Raises:
+        ValueError: If the image information cannot be retrieved.
+
+    """
+    image_info = get_oiio_info_for_input(path.as_posix())
+    if image_info is None:
+        msg = (
+            f"Failed to get image info for {path}"
+        )
+        raise ValueError(msg)
+    return image_info

--- a/client/ayon_mocha/plugins/load/load_clip.py
+++ b/client/ayon_mocha/plugins/load/load_clip.py
@@ -106,7 +106,7 @@ class LoadClip(MochaLoader):
         project = host.get_current_project()
         clips = project.get_clips()
 
-        # get image info usin OIIO
+        # get image info using OIIO
         try:
             image_info = get_image_info(Path(file_path))
         except ValueError as e:

--- a/client/ayon_mocha/plugins/load/load_clip.py
+++ b/client/ayon_mocha/plugins/load/load_clip.py
@@ -2,11 +2,13 @@
 from __future__ import annotations
 
 import time
+from pathlib import Path
 from typing import ClassVar, Optional
 
 from ayon_core.lib.transcoding import IMAGE_EXTENSIONS
 from ayon_core.pipeline import get_representation_path, registered_host
-from ayon_mocha.api.lib import update_ui
+from ayon_core.pipeline.load import LoadError
+from ayon_mocha.api.lib import get_image_info, update_ui
 from ayon_mocha.api.pipeline import (
     Container,
     MochaProHost,
@@ -85,7 +87,16 @@ class LoadClip(MochaLoader):
         host.remove_container(Container(**container))
 
     def update(self, container: dict, context: dict) -> None:
-        """Update a container."""
+        """Update a container.
+
+        Args:
+            container (dict): Container to update.
+            context (dict): Context to update the container to.
+
+        Raises:
+            LoadError: If the image info cannot be retrieved.
+
+        """
         host: MochaProHost = registered_host()
 
         version_entity = context["version"]
@@ -94,8 +105,20 @@ class LoadClip(MochaLoader):
         file_path = get_representation_path(repre_entity)
         project = host.get_current_project()
         clips = project.get_clips()
+
+        # get image info usin OIIO
+        try:
+            image_info = get_image_info(Path(file_path))
+        except ValueError as e:
+            msg = f"Failed to get image info for {file_path}: {e}"
+            raise LoadError(msg) from e
+
         try:
             clips[container["objectName"]].relink(file_path)
+            clips[container["objectName"]].frame_size = (
+                image_info.get("width", 1920),
+                image_info.get("height", 1080),
+            )
         except KeyError:
             self.log.warning("Clip %s not found", container["objectName"])
         update_ui()

--- a/client/ayon_mocha/plugins/load/load_trackable_clip.py
+++ b/client/ayon_mocha/plugins/load/load_trackable_clip.py
@@ -2,12 +2,13 @@
 from __future__ import annotations
 
 import time
+from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar, Optional
 
 from ayon_core.lib.transcoding import IMAGE_EXTENSIONS
 from ayon_core.pipeline import get_representation_path, registered_host
 from ayon_core.pipeline.load import LoadError
-from ayon_mocha.api.lib import update_ui
+from ayon_mocha.api.lib import get_image_info, update_ui
 from ayon_mocha.api.pipeline import (
     Container,
     MochaProHost,
@@ -54,6 +55,21 @@ class LoadTrackableClip(MochaLoader):
             # project.parameter([current_clip, "name"]).set(name)
 
             file_path = self.filepath_from_context(context)
+
+            try:
+                image_info = get_image_info(file_path)
+            except ValueError as exc:
+                msg = (
+                    f"Failed to get image info from {file_path}: {exc}"
+                )
+                raise LoadError(msg) from exc
+
+            # set clip properties
+            current_clip.frame_size = (
+                image_info.get("width", 1920),
+                image_info.get("height", 1080)
+            )
+
             current_clip.relink(file_path)
 
             for cnt in host.get_containers():
@@ -90,7 +106,12 @@ class LoadTrackableClip(MochaLoader):
         host.remove_container(Container(**container))
 
     def update(self, container: dict, context: dict) -> None:
-        """Update a container."""
+        """Update a container.
+
+        Raises:
+            LoadError: If the clip information cannot be determined.
+
+        """
         host: MochaProHost = registered_host()
 
         version_entity = context["version"]
@@ -99,8 +120,19 @@ class LoadTrackableClip(MochaLoader):
         file_path = get_representation_path(repre_entity)
         project = host.get_current_project()
         clips = project.get_clips()
+
+        try:
+            image_info = get_image_info(Path(file_path))
+        except ValueError as exc:
+            msg = f"Failed to get image info from {file_path}: {exc}"
+            raise LoadError(msg) from exc
         try:
             clips[container["objectName"]].relink(file_path)
+            # set clip properties
+            clips[container["objectName"]].frame_size = (
+                image_info.get("width", 1920),
+                image_info.get("height", 1080),
+            )
         except KeyError:
             self.log.warning("Clip %s not found", container["objectName"])
         update_ui()

--- a/client/ayon_mocha/plugins/load/load_trackable_clip.py
+++ b/client/ayon_mocha/plugins/load/load_trackable_clip.py
@@ -57,7 +57,7 @@ class LoadTrackableClip(MochaLoader):
             file_path = self.filepath_from_context(context)
 
             try:
-                image_info = get_image_info(file_path)
+                image_info = get_image_info(Path(file_path))
             except ValueError as exc:
                 msg = (
                     f"Failed to get image info from {file_path}: {exc}"

--- a/stubs/mocha/project.pyi
+++ b/stubs/mocha/project.pyi
@@ -188,7 +188,7 @@ class Clip:
     color_parameters: ColorParameters
     first_frame_offset: int
     frame_rate: float
-    frame_size: float
+    frame_size: tuple(int, int)
     psets: ParameterSet
     def __init__(self,
         clip_path: str,


### PR DESCRIPTION
## Changelog Description
When default trackable clip is loaded, resolution is correctly set. Since Mocha isn't exposing any Python API to determine resolution, this is using OIIO to get it.

Closes #12 

## Testing notes:
Load in any non-HD clip (because default is 1920x1080)
Check the resolution
