### PR TITLE
Fix broken workfiles on Linux

### DIFF
--- a/client/ayon_mocha/api/lib.py
+++ b/client/ayon_mocha/api/lib.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from shutil import copyfile
 from typing import TYPE_CHECKING, Any, Optional, Union
 
-from mocha import REGISTRY_APPLICATION_NAME, get_mocha_exec_name, ui
+from mocha import REGISTRY_APPLICATION_NAME, ui
 from mocha.exporters import ShapeDataExporter, TrackingDataExporter
 from mocha.project import Clip, Project
 from qtpy.QtWidgets import QApplication
@@ -54,6 +54,20 @@ class ExporterProcessInfo:
     staging_dir: Path
     options: dict[str, bool]
 
+
+def get_mocha_exec_name(_: str) -> str:
+    """Get the name of the Mocha executable.
+
+    This function replaces the original `get_mocha_exec_name` function
+    because of the bug where it doesn't work on Linux.
+
+    Args:
+        _: Application name (not used in this implementation).
+
+    Returns:
+        str: Path to the Mocha executable.
+    """
+    return sys.executable
 
 def get_main_window() -> QtWidgets.QWidget:
     """Get the main window of the application.

--- a/client/ayon_mocha/api/lib.py
+++ b/client/ayon_mocha/api/lib.py
@@ -69,6 +69,7 @@ def get_mocha_exec_name(_: str) -> str:
     """
     return sys.executable
 
+
 def get_main_window() -> QtWidgets.QWidget:
     """Get the main window of the application.
 

--- a/client/ayon_mocha/api/lib.py
+++ b/client/ayon_mocha/api/lib.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 
 from ayon_core.lib.transcoding import get_oiio_info_for_input
 from mocha import REGISTRY_APPLICATION_NAME, ui
-
 from mocha.exporters import ShapeDataExporter, TrackingDataExporter
 from mocha.project import Clip, Project
 from qtpy.QtWidgets import QApplication

--- a/client/ayon_mocha/plugins/publish/collect_mocha_paths.py
+++ b/client/ayon_mocha/plugins/publish/collect_mocha_paths.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar
 
 import pyblish.api
-from mocha import get_mocha_exec_name
+from ayon_mocha.api.lib import get_mocha_exec_name
 
 if TYPE_CHECKING:
     from logging import Logger


### PR DESCRIPTION
## Changelog Description
Workaround for bug in Mocha preventing workfile tool to work correctly on Linux.

## Additional review information
`get_mocha_exec_name` doesn't work on linux, fortunately we can replace it with `sys.executable`

## Testing notes:
1. run Mocha on Linux
2. using Workfile tool should work as expected - saving/loading

Closing #14 