### PR TITLE
Chore: Allow per project addon version

### DIFF
--- a/package.py
+++ b/package.py
@@ -15,6 +15,7 @@ version = "1.0.0+dev"
 # - do not specify if there is no client code
 client_dir = "ayon_mocha"
 app_host_name = "mocha"
+project_can_override_addon_version = True
 
 # Version compatibility with AYON server
 ayon_server_version = ">=1.1.2"


### PR DESCRIPTION
## Changelog Description
Addon can be used in per-project bundles.

## Additional informatio
I didn't find any conflicts that would not allow to use the addon in per project bundles.

## Testing notes:
1. Addon can be used in per-project bundles.