### PR TITLE
Create: Use kwargs to call product name functions

### DIFF
--- a/client/ayon_mocha/plugins/create/create_workfile.py
+++ b/client/ayon_mocha/plugins/create/create_workfile.py
@@ -47,11 +47,12 @@ class CreateWorkfile(MochaCreator, AutoCreator):
                 project_name, folder_entity["id"], task_name
             )
             product_name = self.get_product_name(
-                project_name,
-                folder_entity,
-                task_entity,
-                variant,
-                host_name,
+                project_name=project_name,
+                project_entity=project_entity,
+                folder_entity=folder_entity,
+                task_entity=task_entity,
+                variant=variant,
+                host_name=host_name,
             )
             data = {
                 "folderPath": folder_path,
@@ -84,11 +85,12 @@ class CreateWorkfile(MochaCreator, AutoCreator):
                 project_name, folder_entity["id"], task_name
             )
             product_name = self.get_product_name(
-                project_name,
-                folder_entity,
-                task_entity,
-                variant,
-                host_name,
+                project_name=project_name,
+                project_entity=project_entity,
+                folder_entity=folder_entity,
+                task_entity=task_entity,
+                variant=variant,
+                host_name=host_name,
             )
 
             current_instance["folderPath"] = folder_entity["path"]


### PR DESCRIPTION
## Changelog Description
Use kwargs to call product name functions and use cached data to call them if possible.

## Additional review information
This is preparation for future change in `get_product_name` functionality and update of already added change in `get_product_name` method.

## Testing notes:
1. Product names are calculated correctly.
