### PR TITLE
CI: Fix Mkdocs Automation

### DIFF
--- a/.github/workflows/deploy_mkdocs.yml
+++ b/.github/workflows/deploy_mkdocs.yml
@@ -1,0 +1,20 @@
+name: Deploy MkDocs
+
+on:
+  push:
+    tags:
+      - "*"
+    branches:
+      - "bugfix/18-fix-mkdocs-ci"
+  workflow_dispatch:
+
+jobs:
+  build-mk-docs:
+    # FIXME: Update @develop to @main after `ops-repo-automation` release.
+    uses: ynput/ops-repo-automation/.github/workflows/deploy_mkdocs.yml@develop
+    with:
+      repo: ${{ github.repository }}
+    secrets:
+      YNPUT_BOT_TOKEN: ${{ secrets.YNPUT_BOT_TOKEN }}
+      CI_USER: ${{ secrets.CI_USER }}
+      CI_EMAIL: ${{ secrets.CI_EMAIL }}

--- a/.github/workflows/deploy_mkdocs.yml
+++ b/.github/workflows/deploy_mkdocs.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - "*"
-    branches:
-      - "bugfix/18-fix-mkdocs-ci"
   workflow_dispatch:
 
 jobs:

--- a/create_package.py
+++ b/create_package.py
@@ -212,6 +212,29 @@ def find_files_in_subdir(
     return output
 
 
+def update_pyproject_version(log: logging.Logger) -> None:
+    pyproject_toml = os.path.join(CURRENT_ROOT, "pyproject.toml")
+    if not os.path.exists(pyproject_toml):
+        log.info("Did not find pyproject.toml in root directory. Skipping")
+        return
+
+    line_idx = None
+    new_lines = []
+    with open(pyproject_toml, encoding="utf-8") as stream:
+        for idx, line in enumerate(stream.readlines()):
+            if line_idx is None and line.startswith("version"):
+                line_idx = idx
+            new_lines.append(line)
+
+    if line_idx is None:
+        log.info("Failed to find version in pyproject.toml. Skipping.")
+        return
+
+    new_lines[line_idx] = f'version = "{ADDON_VERSION}"\n'
+    with open(pyproject_toml, "w", encoding="utf-8") as stream:
+        stream.write("".join(new_lines))
+
+
 def update_client_version(log: logging.Logger) -> None:
     """Update version in client code if version.py is present."""
     if not ADDON_CLIENT_DIR:
@@ -452,6 +475,8 @@ def main(
 
     if not output_dir:
         output_dir = os.path.join(CURRENT_ROOT, "package")
+
+    update_pyproject_version(log)
 
     has_client_code = bool(ADDON_CLIENT_DIR)
     if has_client_code:

--- a/create_package.py
+++ b/create_package.py
@@ -213,6 +213,7 @@ def find_files_in_subdir(
 
 
 def update_pyproject_version(log: logging.Logger) -> None:
+    """Update version in pyproject.toml if it exists."""
     pyproject_toml = os.path.join(CURRENT_ROOT, "pyproject.toml")
     if not os.path.exists(pyproject_toml):
         log.info("Did not find pyproject.toml in root directory. Skipping")
@@ -220,19 +221,19 @@ def update_pyproject_version(log: logging.Logger) -> None:
 
     line_idx = None
     new_lines = []
-    with open(pyproject_toml, encoding="utf-8") as stream:
-        for idx, line in enumerate(stream.readlines()):
-            if line_idx is None and line.startswith("version"):
-                line_idx = idx
-            new_lines.append(line)
+    for idx, line in enumerate(
+        Path(pyproject_toml).read_text(encoding="utf-8").splitlines()
+    ):
+        if line_idx is None and line.startswith("version"):
+            line_idx = idx
+        new_lines.append(line)
 
     if line_idx is None:
         log.info("Failed to find version in pyproject.toml. Skipping.")
         return
 
-    new_lines[line_idx] = f'version = "{ADDON_VERSION}"\n'
-    with open(pyproject_toml, "w", encoding="utf-8") as stream:
-        stream.write("".join(new_lines))
+    new_lines[line_idx] = f'version = "{ADDON_VERSION}"'
+    Path(pyproject_toml).write_text("\n".join(new_lines), encoding="utf-8")
 
 
 def update_client_version(log: logging.Logger) -> None:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,12 +11,12 @@ theme:
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
       toggle:
-        icon: material/toggle-switch-off-outline
+        icon: material/weather-sunny
         name: Switch to light mode
     - media: "(prefers-color-scheme: light)"
       scheme: default
       toggle:
-        icon: material/toggle-switch
+        icon: material/weather-night
         name: Switch to dark mode
   logo: img/ay-symbol-blackw-full.png
   favicon: img/favicon.ico

--- a/mkdocs_requirements.txt
+++ b/mkdocs_requirements.txt
@@ -1,0 +1,9 @@
+mkdocs-material >= 9.6.7
+mkdocs-autoapi >= 0.4.0
+mkdocstrings-python >= 1.16.2
+mkdocs-minify-plugin >= 0.8.0
+markdown-checklist >= 0.4.4
+mdx-gh-links >= 0.4
+pymdown-extensions >= 10.14.3
+mike >= 2.1.3
+mkdocstrings-shell >= 1.0.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,17 +26,6 @@ attrs = "^24.3.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "^1.14.1"
-tomlkit = "^0.13.2"
-requests = "^2.32.3"
-mkdocs-material = "^9.6.7"
-mkdocs-autoapi = "^0.4.0"
-mkdocstrings-python = "^1.16.2"
-mkdocs-minify-plugin = "^0.8.0"
-markdown-checklist = "^0.4.4"
-mdx-gh-links = "^0.4"
-pymdown-extensions = "^10.14.3"
-mike = "^2.1.3"
-mkdocstrings-shell = "^1.0.2"
 
 [poetry.group.dev.dependencies]
 # test dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [tool.poetry]
 name = "ayon-mocha"
-version = "1.0.0"
+version = "1.0.1+dev"
 description = ""
 authors = ["Ynput Team <team@ynput.io>"]
 readme = "README.md"


### PR DESCRIPTION
## Changelog Description

This PR ports https://github.com/ynput/ayon-core/pull/1441 fixes for applications addon.

- Add a CI action to trigger MK Docs deployment on creating new tags.
when testing the CI action manually (trigger from Action tab manually on GH), it will generate a `dummy-build` version that will be deleted as soon as a tag is created.
- Revert changes in `pyproject.toml` from #11

resolve #18 

## Additional Notes

This PR add some cosmetics: 
1. update light and dark mode icons. 
2. move requirements file to root location of the repo to avoid moving it along with the docs build.

## Testing notes:
1. go to https://docs.ayon.dev/ayon-<>/latest/ you should find light/dark icons are updated and the latest is pointing to `test-build`.
since the workflow doesn't exist in main branch yet, I had to add on push temporarily in 8033cbce6a7f709f2eb997f970e618963684845f to run the action and revert it in a later commit.