### PR TITLE
🏛️Product base types: add support to creators

### DIFF
--- a/client/ayon_mocha/api/pipeline.py
+++ b/client/ayon_mocha/api/pipeline.py
@@ -190,8 +190,8 @@ class MochaProHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
             dst_path (str, optional): The destination path to save the file to.
                 Defaults to None.
 
-        Todo (antirotor): This needs to display error if the project
-            isn't initialized yet.
+        Todo:
+            This needs to display error if the project isn't initialized yet.
             https://github.com/ynput/ayon-core/issues/1075
 
         """
@@ -239,13 +239,13 @@ class MochaProHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         data = self.get_ayon_data()
         containers_dicts = list(self.get_containers())
         containers = [
-            Container(**_container) for _container in containers_dicts
+            Container(**container_) for container_ in containers_dicts
         ]
         to_remove = [
             idx
-            for idx, _container in enumerate(containers)
-            if _container.name == container.name
-            and _container.namespace == container.namespace
+            for idx, container_ in enumerate(containers)
+            if container_.name == container.name
+            and container_.namespace == container.namespace
         ]
         for idx in reversed(to_remove):
             containers.pop(idx)
@@ -265,19 +265,19 @@ class MochaProHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         data = self.get_ayon_data()
         containers_dicts = list(self.get_containers())
         containers = [
-            Container(**_container) for _container in containers_dicts
+            Container(**container_) for container_ in containers_dicts
         ]
         to_remove = [
             idx
-            for idx, _container in enumerate(containers)
-            if _container.name == container.name
-            and _container.namespace == container.namespace
+            for idx, container_ in enumerate(containers)
+            if container_.name == container.name
+            and container_.namespace == container.namespace
         ]
         for idx in reversed(to_remove):
             containers.pop(idx)
 
         data[MOCHA_CONTAINERS_KEY] = [
-            dataclasses.asdict(_container) for _container in containers]
+            dataclasses.asdict(container_) for container_ in containers]
 
         self.update_ayon_data(data)
 

--- a/client/ayon_mocha/plugins/create/create_shape_data.py
+++ b/client/ayon_mocha/plugins/create/create_shape_data.py
@@ -21,6 +21,7 @@ class CreateShapeData(MochaCreator):
     label = "Shape Data"
     description = __doc__
     product_type = "matteshapes"
+    product_base_type = "matteshapes"
     icon = "circle"
 
     def get_attr_defs_for_instance(

--- a/client/ayon_mocha/plugins/create/create_tracking_points.py
+++ b/client/ayon_mocha/plugins/create/create_tracking_points.py
@@ -23,6 +23,7 @@ class CreateTrackingPoints(MochaCreator):
     label = "Track Points"
     description = __doc__
     product_type = "trackpoints"
+    product_base_type = "trackpoints"
     icon = "cubes"
 
     def get_attr_defs_for_instance(self, instance: CreatedInstance) -> list:

--- a/client/ayon_mocha/plugins/create/create_workfile.py
+++ b/client/ayon_mocha/plugins/create/create_workfile.py
@@ -9,6 +9,7 @@ class CreateWorkfile(MochaCreator, AutoCreator):
     identifier = "io.ayon.creators.mochapro.workfiles"
     label = "Workfile"
     product_type = "workfile"
+    product_base_type = "workfile"
     icon = "fa5.file"
 
     default_variant = "Main"

--- a/client/ayon_mocha/plugins/publish/collect_shapes.py
+++ b/client/ayon_mocha/plugins/publish/collect_shapes.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
+import inspect
 from typing import TYPE_CHECKING, ClassVar
 
 import pyblish.api
@@ -29,19 +30,28 @@ class CollectShapes(pyblish.api.InstancePlugin):
         create_context: CreateContext,
         layer_name: str,
         product_type: str,
+        product_base_type: str,
         variant: str) -> str:
         """Return the new product name."""
         sanitized_layer_name = layer_name.replace(" ", "_")
         variant = f"{sanitized_layer_name}{variant.capitalize()}"
 
-        return get_product_name(
-            project_name=create_context.project_name,
-            task_name=create_context.get_current_task_name(),
-            task_type=create_context.get_current_task_type(),
-            host_name=create_context.host_name,
-            product_type=product_type,
-            variant=variant,
-        )
+        get_product_name_kwargs = {
+            "project_name": create_context.project_name,
+            "task_name": create_context.get_current_task_name(),
+            "task_type": create_context.get_current_task_type(),
+            "host_name": create_context.host_name,
+            "product_type": product_type,
+            "variant": variant,
+        }
+
+        signature = inspect.signature(get_product_name)
+        if "product_base_type" not in signature.parameters:
+            get_product_name_kwargs["product_base_name"] = (
+                product_base_type
+            )
+
+        return get_product_name(**get_product_name_kwargs)
 
     def process(self, instance: pyblish.api.Instance) -> None:
         """Process the instance.
@@ -91,8 +101,9 @@ class CollectShapes(pyblish.api.InstancePlugin):
             new_instance.data["productName"] = self.new_product_name(
                 instance.context.data["create_context"],
                 layer.name,
-                instance.data["productType"],
-                instance.data["variant"],
+                product_type=instance.data["productType"],
+                product_base_type=instance.data["productBaseType"],
+                variant=instance.data["variant"],
             )
             self.set_layer_data_on_instance(new_instance, layer)
         if layers:

--- a/client/ayon_mocha/plugins/publish/collect_shapes.py
+++ b/client/ayon_mocha/plugins/publish/collect_shapes.py
@@ -1,8 +1,8 @@
 """Collect layers for shape export."""
 from __future__ import annotations
 
-from copy import deepcopy
 import inspect
+from copy import deepcopy
 from typing import TYPE_CHECKING, ClassVar
 
 import pyblish.api

--- a/client/ayon_mocha/plugins/publish/collect_shapes.py
+++ b/client/ayon_mocha/plugins/publish/collect_shapes.py
@@ -35,12 +35,7 @@ class CollectShapes(pyblish.api.InstancePlugin):
         sanitized_layer_name = layer_name.replace(" ", "_")
         variant = f"{sanitized_layer_name}{variant.capitalize()}"
 
-        get_product_name_kwargs = {
-            "project_name": create_context.project_name,
-            "host_name": create_context.host_name,
-            "product_type": product_type,
-            "variant": variant,
-        }
+        get_product_name_kwargs = {}
 
         if getattr(get_product_name, "use_entities", False):
             get_product_name_kwargs.update({
@@ -54,7 +49,13 @@ class CollectShapes(pyblish.api.InstancePlugin):
                 "task_type": create_context.get_current_task_type(),
             })
 
-        return get_product_name(**get_product_name_kwargs)
+        return get_product_name(
+            project_name=create_context.project_name,
+            host_name=create_context.host_name,
+            product_type=product_type,
+            variant=variant,
+            **get_product_name_kwargs
+        )
 
     def process(self, instance: pyblish.api.Instance) -> None:
         """Process the instance.

--- a/client/ayon_mocha/plugins/publish/collect_shapes.py
+++ b/client/ayon_mocha/plugins/publish/collect_shapes.py
@@ -1,7 +1,6 @@
 """Collect layers for shape export."""
 from __future__ import annotations
 
-import inspect
 from copy import deepcopy
 from typing import TYPE_CHECKING, ClassVar
 
@@ -38,18 +37,22 @@ class CollectShapes(pyblish.api.InstancePlugin):
 
         get_product_name_kwargs = {
             "project_name": create_context.project_name,
-            "task_name": create_context.get_current_task_name(),
-            "task_type": create_context.get_current_task_type(),
             "host_name": create_context.host_name,
             "product_type": product_type,
             "variant": variant,
         }
 
-        signature = inspect.signature(get_product_name)
-        if "product_base_type" not in signature.parameters:
-            get_product_name_kwargs["product_base_name"] = (
-                product_base_type
-            )
+        if getattr(get_product_name, "use_entities", False):
+            get_product_name_kwargs.update({
+                "folder_entity": create_context.get_current_folder_entity(),
+                "task_entity": create_context.get_current_task_entity(),
+                "product_base_type": product_base_type,
+            })
+        else:
+            get_product_name_kwargs.update({
+                "task_name": create_context.get_current_task_name(),
+                "task_type": create_context.get_current_task_type(),
+            })
 
         return get_product_name(**get_product_name_kwargs)
 

--- a/client/ayon_mocha/plugins/publish/collect_trackpoints.py
+++ b/client/ayon_mocha/plugins/publish/collect_trackpoints.py
@@ -1,8 +1,8 @@
 """Collect instances for publishing."""
 from __future__ import annotations
 
-from copy import deepcopy
 import inspect
+from copy import deepcopy
 from typing import TYPE_CHECKING, ClassVar
 
 import pyblish.api

--- a/client/ayon_mocha/plugins/publish/collect_trackpoints.py
+++ b/client/ayon_mocha/plugins/publish/collect_trackpoints.py
@@ -1,7 +1,6 @@
 """Collect instances for publishing."""
 from __future__ import annotations
 
-import inspect
 from copy import deepcopy
 from typing import TYPE_CHECKING, ClassVar
 
@@ -38,16 +37,26 @@ class CollectTrackpoints(pyblish.api.InstancePlugin):
 
         get_product_name_kwargs = {
             "project_name": create_context.project_name,
-            "task_name": create_context.get_current_task_name(),
-            "task_type": create_context.get_current_task_type(),
             "host_name": create_context.host_name,
             "product_type": product_type,
-            "variant": variant
+            "variant": variant,
         }
 
-        signature = inspect.signature(get_product_name)
-        if "product_base_type" in signature.parameters:
-            get_product_name_kwargs["product_base_type"] = product_base_type
+        if getattr(get_product_name, "use_entities", False):
+            get_product_name_kwargs.update(
+                {
+                    "folder_entity": create_context.get_current_folder_entity(),
+                    "task_entity": create_context.get_current_task_entity(),
+                    "product_base_type": product_base_type,
+                }
+            )
+        else:
+            get_product_name_kwargs.update(
+                {
+                    "task_name": create_context.get_current_task_name(),
+                    "task_type": create_context.get_current_task_type(),
+                }
+            )
 
         return get_product_name(**get_product_name_kwargs)
 

--- a/client/ayon_mocha/plugins/publish/collect_trackpoints.py
+++ b/client/ayon_mocha/plugins/publish/collect_trackpoints.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
+import inspect
 from typing import TYPE_CHECKING, ClassVar
 
 import pyblish.api
@@ -29,19 +30,26 @@ class CollectTrackpoints(pyblish.api.InstancePlugin):
         create_context: CreateContext,
         layer_name: str,
         product_type: str,
+        product_base_type: str,
         variant: str) -> str:
         """Return the new product name."""
         sanitized_layer_name = layer_name.replace(" ", "_")
         variant = f"{sanitized_layer_name}{variant.capitalize()}"
 
-        return get_product_name(
-            project_name=create_context.project_name,
-            task_name=create_context.get_current_task_name(),
-            task_type=create_context.get_current_task_type(),
-            host_name=create_context.host_name,
-            product_type=product_type,
-            variant=variant,
-        )
+        get_product_name_kwargs = {
+            "project_name": create_context.project_name,
+            "task_name": create_context.get_current_task_name(),
+            "task_type": create_context.get_current_task_type(),
+            "host_name": create_context.host_name,
+            "product_type": product_type,
+            "variant": variant
+        }
+
+        signature = inspect.signature(get_product_name)
+        if "product_base_type" in signature.parameters:
+            get_product_name_kwargs["product_base_type"] = product_base_type
+
+        return get_product_name(**get_product_name_kwargs)
 
     def process(self, instance: pyblish.api.Instance) -> None:
         """Process the instance.

--- a/client/ayon_mocha/plugins/publish/collect_trackpoints.py
+++ b/client/ayon_mocha/plugins/publish/collect_trackpoints.py
@@ -35,12 +35,7 @@ class CollectTrackpoints(pyblish.api.InstancePlugin):
         sanitized_layer_name = layer_name.replace(" ", "_")
         variant = f"{sanitized_layer_name}{variant.capitalize()}"
 
-        get_product_name_kwargs = {
-            "project_name": create_context.project_name,
-            "host_name": create_context.host_name,
-            "product_type": product_type,
-            "variant": variant,
-        }
+        get_product_name_kwargs = {}
 
         if getattr(get_product_name, "use_entities", False):
             get_product_name_kwargs.update({
@@ -54,7 +49,13 @@ class CollectTrackpoints(pyblish.api.InstancePlugin):
                 "task_type": create_context.get_current_task_type(),
             })
 
-        return get_product_name(**get_product_name_kwargs)
+        return get_product_name(
+            project_name=create_context.project_name,
+            host_name=create_context.host_name,
+            product_type=product_type,
+            variant=variant,
+            **get_product_name_kwargs
+        )
 
     def process(self, instance: pyblish.api.Instance) -> None:
         """Process the instance.

--- a/client/ayon_mocha/plugins/publish/collect_trackpoints.py
+++ b/client/ayon_mocha/plugins/publish/collect_trackpoints.py
@@ -43,20 +43,16 @@ class CollectTrackpoints(pyblish.api.InstancePlugin):
         }
 
         if getattr(get_product_name, "use_entities", False):
-            get_product_name_kwargs.update(
-                {
-                    "folder_entity": create_context.get_current_folder_entity(),
-                    "task_entity": create_context.get_current_task_entity(),
-                    "product_base_type": product_base_type,
-                }
-            )
+            get_product_name_kwargs.update({
+                "folder_entity": create_context.get_current_folder_entity(),
+                "task_entity": create_context.get_current_task_entity(),
+                "product_base_type": product_base_type,
+            })
         else:
-            get_product_name_kwargs.update(
-                {
-                    "task_name": create_context.get_current_task_name(),
-                    "task_type": create_context.get_current_task_type(),
-                }
-            )
+            get_product_name_kwargs.update({
+                "task_name": create_context.get_current_task_name(),
+                "task_type": create_context.get_current_task_type(),
+            })
 
         return get_product_name(**get_product_name_kwargs)
 


### PR DESCRIPTION
## Changelog Description
This is adding product base types support to existing creators. In this stage, it only mimics the product types. This has to be done in all DCC before further changes can be done in https://github.com/ynput/ayon-core to finalize the support.

## Additional review information
Additional PRs should check/address the usage of `product_type` as family - plugins shouldn't rely on having product type as family because if/when this is customized, workflow could stop work or behave unpredicable.

## Testing notes:
Everything should work as before.

> [!WARNING]
> Note that this requires https://github.com/ynput/ayon-core/pull/1462