### PR TITLE
🏛️Product base types: product type settings for creators

### DIFF
--- a/client/ayon_mocha/api/plugin.py
+++ b/client/ayon_mocha/api/plugin.py
@@ -32,14 +32,15 @@ class MochaCreator(Creator):
 
         """
         instance = CreatedInstance(
-            self.product_type,
-            product_name,
-            instance_data,
-            self,
+            product_type=self.product_type,
+            product_name=product_name,
+            data=instance_data,
+            creator=self,
+            product_base_type=self.product_base_type,
         )
         self._add_instance_to_context(instance)
         host: MochaProHost = self.host
-        host.add_publish_instance(instance.data_to_store())\
+        host.add_publish_instance(instance.data_to_store())
 
         return instance
 

--- a/client/ayon_mocha/plugins/create/create_workfile.py
+++ b/client/ayon_mocha/plugins/create/create_workfile.py
@@ -71,7 +71,11 @@ class CreateWorkfile(MochaCreator, AutoCreator):
             )
             self.log.info("Auto-creating workfile instance...")
             current_instance = CreatedInstance(
-                self.product_type, product_name, data, self
+                product_type=self.product_type,
+                product_name=product_name,
+                data=data,
+                creator=self,
+                product_base_type=self.product_base_type
             )
             self._add_instance_to_context(current_instance)
         elif (

--- a/client/ayon_mocha/plugins/load/load_clip.py
+++ b/client/ayon_mocha/plugins/load/load_clip.py
@@ -25,7 +25,7 @@ class LoadClip(MochaLoader):
     icon = "code-fork"
     color = "orange"
 
-    product_base_types = {"*"}
+    product_base_types: ClassVar[set[str]] = {"*"}
     product_types = product_base_types
     representations: ClassVar[set[str]] = {"*"}
     extensions: ClassVar[set[str]] = {

--- a/client/ayon_mocha/plugins/load/load_clip.py
+++ b/client/ayon_mocha/plugins/load/load_clip.py
@@ -25,7 +25,8 @@ class LoadClip(MochaLoader):
     icon = "code-fork"
     color = "orange"
 
-    product_types: ClassVar[set[str]] = {"*"}
+    product_base_types = {"*"}
+    product_types = product_base_types
     representations: ClassVar[set[str]] = {"*"}
     extensions: ClassVar[set[str]] = {
         ext.lstrip(".") for ext in IMAGE_EXTENSIONS}

--- a/client/ayon_mocha/plugins/load/load_trackable_clip.py
+++ b/client/ayon_mocha/plugins/load/load_trackable_clip.py
@@ -27,7 +27,7 @@ class LoadTrackableClip(MochaLoader):
     icon = "code-fork"
     color = "orange"
 
-    product_base_types = {"*"}
+    product_base_types: ClassVar[set[str]] = {"*"}
     product_types = product_base_types
     representations: ClassVar[set[str]] = {"*"}
     extensions: ClassVar[set[str]] = {

--- a/client/ayon_mocha/plugins/load/load_trackable_clip.py
+++ b/client/ayon_mocha/plugins/load/load_trackable_clip.py
@@ -27,7 +27,8 @@ class LoadTrackableClip(MochaLoader):
     icon = "code-fork"
     color = "orange"
 
-    product_types: ClassVar[set[str]] = {"*"}
+    product_base_types = {"*"}
+    product_types = product_base_types
     representations: ClassVar[set[str]] = {"*"}
     extensions: ClassVar[set[str]] = {
         ext.lstrip(".") for ext in IMAGE_EXTENSIONS}

--- a/package.py
+++ b/package.py
@@ -18,14 +18,14 @@ app_host_name = "mocha"
 project_can_override_addon_version = True
 
 # Version compatibility with AYON server
-ayon_server_version = ">=1.1.2"
+ayon_server_version = ">=1.13.0"
 # Version compatibility with AYON launcher
 # ayon_launcher_version = ">=1.0.2"
 
 # Mapping of addon name to version requirements
 # - addon with specified version range must exist to be able to use this addon
 ayon_required_addons = {
-    "core": ">=1.0.12",
+    "core": ">=1.8.0",
 }
 # Mapping of addon name to version requirements
 # - if addon is used in same bundle the version range must be valid

--- a/ruff.toml
+++ b/ruff.toml
@@ -58,6 +58,7 @@ ignore = [
     "S404",    # subprocess module is possibly insecure
     "PLC0415", # import must be on top of the file
     "CPY001",  # missing copyright header
+    "RUF067",  # code in __init__.py__
 ]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.

--- a/server/settings/creator_plugins.py
+++ b/server/settings/creator_plugins.py
@@ -414,6 +414,17 @@ class Mocha2025TrackingModel(BaseSettingsModel):
         enum_resolver=tracking_exporter_enum_2025)
 
 
+class ProductTypeItemModel(BaseSettingsModel):
+    _layout = "compact"
+    product_type: str = SettingsField(
+        title="Product Type",
+        decription="Product type name"
+    )
+    label: str = SettingsField(
+        title="Label",
+        description="Label to display in UI for the product type",
+    )
+
 class CreateTrackingPointsModel(BaseSettingsModel):
     """Settings for creating tracking points."""
     enabled: bool = SettingsField(
@@ -424,6 +435,13 @@ class CreateTrackingPointsModel(BaseSettingsModel):
     mocha_2025: Mocha2025TrackingModel = SettingsField(
         default_factory=Mocha2025TrackingModel,
         title="Mocha Pro 2025")
+    product_type_items: list[ProductTypeItemModel] = SettingsField(
+        default_factory=list,
+        title="Product Type Items",
+        description=(
+            "Optional list of product types this plugin can create."
+        )
+    )
 
 
 class Mocha2024ShapeModel(BaseSettingsModel):
@@ -450,6 +468,13 @@ class CreateShapeDataModel(BaseSettingsModel):
     mocha_2025: Mocha2025ShapeModel = SettingsField(
         default_factory=Mocha2025ShapeModel,
         title="Mocha Pro 2025")
+    product_type_items: list[ProductTypeItemModel] = SettingsField(
+        default_factory=list,
+        title="Product Type Items",
+        description=(
+            "Optional list of product types this plugin can create."
+        )
+    )
 
 
 class MochaProCreatorPlugins(BaseSettingsModel):

--- a/server/settings/creator_plugins.py
+++ b/server/settings/creator_plugins.py
@@ -415,6 +415,7 @@ class Mocha2025TrackingModel(BaseSettingsModel):
 
 
 class ProductTypeItemModel(BaseSettingsModel):
+    """Model for product type item in creator plugins settings."""
     _layout = "compact"
     product_type: str = SettingsField(
         title="Product Type",
@@ -424,6 +425,7 @@ class ProductTypeItemModel(BaseSettingsModel):
         title="Label",
         description="Label to display in UI for the product type",
     )
+
 
 class CreateTrackingPointsModel(BaseSettingsModel):
     """Settings for creating tracking points."""


### PR DESCRIPTION
## Changelog Description
Changing the usage of product_type to product_base_type and adding support to customize product type in creator settings.

## Testing notes:
> [!WARNING]
> You'll need **ynput/ayon-core** 1.8 and higher

* Publishing and loading should work as before
* When you define new product type int the settings, you should be able to see new items in the publisher.
* Product name should work ok, you should be able to see changes if/when appropriate token is used in the template
* Publishing of instances created with new product type and loading them should work

Closes #23 